### PR TITLE
feat(dashboard): replace hardcoded placeholders with real metrics

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -120,11 +120,21 @@ export default function Dashboard() {
                 R$ {stats?.todayRevenue?.toFixed(2) || '0.00'}
               </div>
               <div className="flex items-center text-xs">
-                <span className="text-emerald-400 flex items-center">
-                  <ArrowUpRight className="h-3 w-3 mr-1" />
-                  +12%
-                </span>
-                <span className="text-gray-500 ml-2">vs. ontem</span>
+                {stats?.revenueChange !== undefined && stats?.revenueChange !== 0 ? (
+                  <>
+                    <span className={`flex items-center ${stats.revenueChange > 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                      {stats.revenueChange > 0 ? (
+                        <ArrowUpRight className="h-3 w-3 mr-1" />
+                      ) : (
+                        <ArrowDownRight className="h-3 w-3 mr-1" />
+                      )}
+                      {stats.revenueChange > 0 ? '+' : ''}{stats.revenueChange}%
+                    </span>
+                    <span className="text-gray-500 ml-2">vs. ontem</span>
+                  </>
+                ) : (
+                  <span className="text-gray-400">sem dados de ontem</span>
+                )}
               </div>
             </CardContent>
           </Card>
@@ -141,11 +151,21 @@ export default function Dashboard() {
             <CardContent>
               <div className="text-2xl font-bold text-white mb-1">{stats?.todayAppointments || 0}</div>
               <div className="flex items-center text-xs">
-                <span className="text-emerald-400 flex items-center">
-                  <ArrowUpRight className="h-3 w-3 mr-1" />
-                  +4
-                </span>
-                <span className="text-gray-500 ml-2">vs. ontem</span>
+                {stats?.appointmentsChange !== undefined && stats?.appointmentsChange !== 0 ? (
+                  <>
+                    <span className={`flex items-center ${stats.appointmentsChange > 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                      {stats.appointmentsChange > 0 ? (
+                        <ArrowUpRight className="h-3 w-3 mr-1" />
+                      ) : (
+                        <ArrowDownRight className="h-3 w-3 mr-1" />
+                      )}
+                      {stats.appointmentsChange > 0 ? '+' : ''}{stats.appointmentsChange}
+                    </span>
+                    <span className="text-gray-500 ml-2">vs. ontem</span>
+                  </>
+                ) : (
+                  <span className="text-gray-400">igual a ontem</span>
+                )}
               </div>
             </CardContent>
           </Card>
@@ -284,13 +304,31 @@ export default function Dashboard() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
-                <AlertCircle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
-                <div>
-                  <p className="text-sm font-medium text-red-200">Nenhum atraso no momento</p>
-                  <p className="text-xs text-red-300/70 mt-1">Operação dentro do prazo!</p>
+              {stats?.delayedAppointments && stats.delayedAppointments.length > 0 ? (
+                <div className="space-y-3">
+                  {stats.delayedAppointments.map((delay: any) => (
+                    <div key={delay.id} className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
+                      <AlertCircle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
+                      <div>
+                        <p className="text-sm font-medium text-red-200">
+                          Agendamento atrasado
+                        </p>
+                        <p className="text-xs text-red-300/70 mt-1">
+                          {delay.delayMinutes} min de atraso • {format(new Date(delay.scheduledAt), 'HH:mm', { locale: ptBR })}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
                 </div>
-              </div>
+              ) : (
+                <div className="bg-emerald-500/10 border border-emerald-500/20 rounded-xl p-4 flex items-start gap-3">
+                  <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0 mt-0.5" />
+                  <div>
+                    <p className="text-sm font-medium text-emerald-200">Nenhum atraso no momento</p>
+                    <p className="text-xs text-emerald-300/70 mt-1">Operação dentro do prazo!</p>
+                  </div>
+                </div>
+              )}
             </CardContent>
           </Card>
         </motion.div>

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -454,10 +454,15 @@ export class DrizzleStorage implements IStorage {
 
   // Dashboard statistics
   async getDashboardStats(businessId: number): Promise<any> {
+    const now = new Date();
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const tomorrow = new Date(today);
     tomorrow.setDate(tomorrow.getDate() + 1);
+
+    // Yesterday's date range
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
 
     const todayAppointments = await this.db
       .select()
@@ -467,6 +472,18 @@ export class DrizzleStorage implements IStorage {
           eq(appointments.businessId, businessId),
           gte(appointments.scheduledAt, today),
           lte(appointments.scheduledAt, tomorrow)
+        )
+      );
+
+    // Yesterday's appointments count
+    const yesterdayAppointments = await this.db
+      .select()
+      .from(appointments)
+      .where(
+        and(
+          eq(appointments.businessId, businessId),
+          gte(appointments.scheduledAt, yesterday),
+          lte(appointments.scheduledAt, today)
         )
       );
 
@@ -482,7 +499,29 @@ export class DrizzleStorage implements IStorage {
         )
       );
 
+    // Yesterday's orders
+    const yesterdayOrders = await this.db
+      .select()
+      .from(serviceOrders)
+      .where(
+        and(
+          eq(serviceOrders.businessId, businessId),
+          gte(serviceOrders.createdAt, yesterday),
+          lte(serviceOrders.createdAt, today),
+          eq(serviceOrders.paymentStatus, "paid")
+        )
+      );
+
     const todayRevenue = todayOrders.reduce((sum, order) => sum + parseFloat(order.amount), 0);
+    const yesterdayRevenue = yesterdayOrders.reduce((sum, order) => sum + parseFloat(order.amount), 0);
+
+    // Calculate percentage change for revenue
+    const revenueChange = yesterdayRevenue > 0 
+      ? Math.round(((todayRevenue - yesterdayRevenue) / yesterdayRevenue) * 100)
+      : todayRevenue > 0 ? 100 : 0;
+
+    // Calculate change for appointments
+    const appointmentsChange = todayAppointments.length - yesterdayAppointments.length;
 
     const weekAgo = new Date(today);
     weekAgo.setDate(weekAgo.getDate() - 7);
@@ -537,13 +576,38 @@ export class DrizzleStorage implements IStorage {
       });
     }
 
+    // Calculate delayed appointments (in-progress appointments past their scheduled end time)
+    const delayedAppointments = todayAppointments.filter(apt => {
+      if (apt.status !== 'in-progress') return false;
+      const scheduledEnd = new Date(apt.scheduledAt);
+      scheduledEnd.setMinutes(scheduledEnd.getMinutes() + (apt.duration || 60));
+      return now > scheduledEnd;
+    }).map(apt => {
+      const scheduledEnd = new Date(apt.scheduledAt);
+      scheduledEnd.setMinutes(scheduledEnd.getMinutes() + (apt.duration || 60));
+      const delayMinutes = Math.round((now.getTime() - scheduledEnd.getTime()) / 60000);
+      return {
+        id: apt.id,
+        scheduledAt: apt.scheduledAt,
+        delayMinutes,
+        customerId: apt.customerId,
+        vehicleId: apt.vehicleId,
+        serviceId: apt.serviceId
+      };
+    });
+
     return {
       todayAppointments: todayAppointments.length,
+      yesterdayAppointments: yesterdayAppointments.length,
+      appointmentsChange,
       todayRevenue,
+      yesterdayRevenue,
+      revenueChange,
       weeklyRevenue,
       ticketMedio,
       weeklyData,
       appointmentsList: todayAppointments,
+      delayedAppointments,
     };
   }
 


### PR DESCRIPTION
- Calculate revenue comparison vs yesterday (percentage change)
- Calculate appointments comparison vs yesterday (absolute change)
- Detect delayed appointments (in-progress past scheduled end time)
- Show green card when no delays, list delays with minutes when present
- Handle edge cases (no data, equal values)